### PR TITLE
Fix: loading screen covered the entire app

### DIFF
--- a/docs/flat-earth/style.css
+++ b/docs/flat-earth/style.css
@@ -1,5 +1,14 @@
 :root { --bg:#0b0e13; --fg:#d7dee8; --dim:#8a97a8; --rule:#232a35; --warn:#e0a33e; }
 * { box-sizing: border-box; }
+
+/* The HTML `hidden` attribute works through the UA stylesheet's
+   `[hidden] { display: none }`, which ANY author rule with an id selector
+   outranks. #loading-screen and #canvas-error both set `display: grid`, so
+   setting `.hidden = true` on them did nothing: the loading screen covered the
+   whole working app at z-index 10 forever, and the empty error card sat over
+   the canvas swallowing drags. Every DOM assertion passed the whole time —
+   the attribute really was set. This rule makes `hidden` mean hidden. */
+[hidden] { display: none !important; }
 body { margin:0; background:var(--bg); color:var(--fg);
        font:14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 #app-header { display:flex; gap:1rem; align-items:center;


### PR DESCRIPTION
`/flat-earth/` shows "Initializing…" forever. The app behind it works completely — every phenomenon builds, every readout computes, the canvas renders — but nothing is visible.

## Cause

`#loading-screen` and `#canvas-error` both set `display: grid`. The HTML `hidden` attribute works through the UA stylesheet's `[hidden] { display: none }`, and any author rule with an id selector outranks it.

So `setLoading(false)` set `hidden = true`, the attribute had no effect, and the overlay stayed at `z-index: 10` over the running app. `#canvas-error` had the same defect and covered the canvas, which would also have swallowed camera drags.

Confirmed in the browser:

```
loadingScreen: { hiddenAttr: true, display: "grid", zIndex: "10" }
canvasError:   { hiddenAttr: true, display: "grid" }
elementFromPoint(centre) -> "loading-status"
```

After the fix both compute to `display: none` and `elementFromPoint(centre)` returns `scene-canvas`.

## Why nothing caught it

The attribute really *was* being set, so every DOM assertion passed. The 43 tests cover the pure-physics layer, which was never involved. And the README's manual checklist opens with "load the page and confirm both panes render" — a reviewer would have stopped at a blank screen, but the checklist was written to catch wrong *pictures*, not a correct picture behind an opaque div.

Only running the app surfaced it.

## Fix

A global `[hidden] { display: none !important; }` rather than per-element `:not([hidden])` selectors, so a future rule cannot reopen the same trap.

43/43 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaKKViSjpuiDgdwVZ3Qfm
