### PR TITLE
Serve local dev JS with a correct MIME type

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,3 +30,5 @@ exclude:
   - flat-earth/test
   - flat-earth/package.json
   - flat-earth/README.md
+  # Local dev server; the published site is served by GitHub Pages.
+  - flat-earth/serve.py

--- a/docs/flat-earth/README.md
+++ b/docs/flat-earth/README.md
@@ -7,9 +7,21 @@ against observation. Design spec:
 ## Run locally
 
     cd docs/flat-earth
-    python -m http.server
+    python serve.py
 
 Open http://localhost:8000
+
+Use `serve.py`, **not** `python -m http.server`. Python's `mimetypes` seeds
+itself from the Windows registry, and on many Windows machines
+`HKEY_CLASSES_ROOT\.js` carries `Content Type = text/plain`. `http.server`
+then serves every module as text/plain and the browser refuses the whole
+import graph under strict MIME checking — a blank page whose only symptom is
+`Expected a JavaScript-or-Wasm module script but the server responded with a
+MIME type of "text/plain"`. Nothing is wrong with the app when this happens.
+`serve.py` pins the types it serves instead of trusting the host registry.
+
+This affects local serving only. GitHub Pages sends the correct
+`text/javascript`, so the published site is unaffected.
 
 ## Tests
 

--- a/docs/flat-earth/serve.py
+++ b/docs/flat-earth/serve.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Static server for local development. Use this instead of `python -m http.server`.
+
+Python's `mimetypes` seeds itself from the Windows registry, and on many
+Windows machines `HKEY_CLASSES_ROOT\\.js` carries `Content Type = text/plain`
+(installers for editors and runtimes commonly set it). `http.server` then
+serves every module as text/plain, and the browser refuses the entire import
+graph under strict MIME checking:
+
+    Failed to load module script: Expected a JavaScript-or-Wasm module script
+    but the server responded with a MIME type of "text/plain".
+
+The result is a blank page and one console error, with nothing wrong in the
+app itself. This server pins the types it serves rather than trusting the
+host's registry, so it behaves the same on every machine.
+
+    python serve.py [port]        # default 8000
+"""
+
+import sys
+from http.server import SimpleHTTPRequestHandler, test
+
+
+class Handler(SimpleHTTPRequestHandler):
+    # Pinned, not merged with the registry-derived defaults: these are the
+    # types the app actually serves, and every one of them is a correctness
+    # requirement rather than a nicety. A wrong type on any of them is a
+    # blank page, not a degraded one.
+    extensions_map = {
+        **SimpleHTTPRequestHandler.extensions_map,
+        '.js': 'text/javascript',
+        '.mjs': 'text/javascript',
+        '.css': 'text/css',
+        '.html': 'text/html',
+        '.json': 'application/json',
+        '.svg': 'image/svg+xml',
+        '': 'application/octet-stream',
+    }
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+    print(f'Flat Earth Lab: http://localhost:{port}/  (Ctrl+C to stop)')
+    test(HandlerClass=Handler, port=port, bind='127.0.0.1')


### PR DESCRIPTION
`python -m http.server` — the command the README told you to run — produces a
blank Flat Earth Lab page on many Windows machines, with one console error:

> Failed to load module script: Expected a JavaScript-or-Wasm module script but
> the server responded with a MIME type of "text/plain".

## Cause

Python's `mimetypes` seeds itself from the Windows registry, and
`HKEY_CLASSES_ROOT\.js` commonly carries `Content Type = text/plain` (editor and
runtime installers set it). `http.server` then labels every module `text/plain`,
and the browser refuses the entire import graph under strict MIME checking.

`.js` and `.mjs` are the only affected extensions — `.css`, `.html`, `.json` and
`.svg` all resolve correctly. That is why the failure looks so narrow: one error,
no styling problems, no missing data, just nothing on screen.

Nothing is wrong with the app when this happens.

## Fix

`serve.py` pins the types it serves rather than trusting the host registry, so it
behaves identically on every machine. The README now points at it and spells out
the symptom, so the next person to hit it recognizes it instead of debugging the
app.

Fixing the registry key instead would repair one machine and no clones — and it
is a system setting, not this project's to change.

`flat-earth/serve.py` is added to the Jekyll excludes so it does not publish.

## Verification

Over HTTP against `serve.py`: all **29 JS files** — application modules and both
vendored Three.js files — return `200` / `text/javascript`. `.css`, `.html` and
`.json` are unchanged and correct.

Not verified visually: the Chrome extension is not connected in this session. The
failing mechanism was the response header, and that is directly checked.

## Scope

Local serving only. GitHub Pages sends `text/javascript`, so the published site
was never affected by this and no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PaKKViSjpuiDgdwVZ3Qfm
